### PR TITLE
[WIP] Make worker groups and kubernetes version configurable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -18,3 +18,32 @@ variable "map_users" {
 
   default = []
 }
+
+variable "kubernetes_version" {
+  default = "1.19"
+}
+
+variable "worker_groups" {
+  default = [
+    {
+      name                          = "worker-group-medium"
+      instance_type                 = "t3.medium"
+      additional_userdata           = ""
+      root_volume_type              = "gp2"
+
+      #autoscaling group section
+      asg_max_size                  = "5"
+      asg_desired_capacity          = "1"
+    },
+    {
+      name                          = "worker-group-large"
+      instance_type                 = "t3.xlarge"
+      additional_userdata           = ""
+      root_volume_type              = "gp2"
+
+      #autoscaling group section
+      asg_max_size         = "8"
+      asg_desired_capacity = "3"
+    },
+  ]
+}


### PR DESCRIPTION
There is still a problem because this PR will assign `mgmt_two` security group to all workers. 

We need to evaluate why we need this to make worker groups really configurable here.